### PR TITLE
Load prompt tools from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .env
 __pycache__
 .ruff_cache
-prompts.txt
+user_inputs.py

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ LANGFUSE_HOST="https://cloud.langfuse.com"
 ```
 12. To utilize the default daily briefing flow, create a Notion page called `Daily Briefings`. Ideally this should be at the root of your Notion workspace.   
 You can utilize other names, but update the `variables` at the top of `main` in `host.py`. 
-13. Update the `system_prompt` in `main` in `plan_exec_agent.py` with a description of who you are and any extra information that will make the model's output better. 
+13. Update the `user_context` in `main` in `plan_exec_agent.py` with a description of who you are, how you like to work (like what communication tools you prefer) and any extra information that will make the model's output better. Update the `base_system_prompt` with any special instructions you want it to take into account. 
 14. The instructions for the LLM on *how* to generate the daily briefing are in the  `query` variable in `plan_exec_agent.py` in the `main` method. Change the step-by-step instructions based on how you want you daily briefing created.  
 For example, if you want the briefing to also check a specific Notion page that has your tasks, the model can also do this
 15. run `python plan_exec_agent.py` to create a daily briefing one time. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Daily Briefing MCP Agent
+# MCP Agent
 
-This will generate a daily briefing from a sources. You do not need to install them all, the code will run without them all installed but their tools will not be accessible. The instructions for all of them are below.
+This is an AI assistant that runs using MCP. 
 
 ## How to install before running
+You must install MCP servers in order to use this application. You do not need to install them all, the code will run without them all installed but their tools will not be accessible. The instructions for all of them are below:
 
 1. create a python venv then `pip install -r requirements.txt`
 2. You need to `git  clone` the following repos and run `npm install` in all the project roots
@@ -72,13 +73,15 @@ The default workflow generates a **daily briefing** over various tools like emai
 2. Update the `user_context` in `main` in `plan_exec_agent.py` with a description of who you are, how you like to work (like what communication tools you prefer) and any extra information that will make the model's output better. Update the `base_system_prompt` with any special instructions you want it to take into account. 
 3. The instructions for the LLM on *how* to generate the daily briefing are in the  `query` variable in `plan_exec_agent.py` in the `main` method. Change the step-by-step instructions based on how you want you daily briefing created.  
 For example, if you want the briefing to also check a specific Notion page that has your tasks, the model can also do this
-4. run `python plan_exec_agent.py` to create a daily briefing one time. 
+4. (Optional) You can alter the `DEFAULT_TOOLS` array at the top of `host.py` to have only these values `["Gmail", "Google Calendar", "Whatsapp", "Exa", "Notion"]` so you don't have to set up every MCP server
+5. run `python plan_exec_agent.py` to create a daily briefing one time. 
 
 ### Run your own Custom Flow
 Create a file called `user_inputs.py` in root directory then add the following constant variables that will control how the assistant runs:
 1. `QUERY` - your request for the MCP assistant
 2. `USER_CONTEXT` - background information on who you are, what your preferences are, how you like to work, etc. Helps the model produce better output
 3. `BASE_SYSTEM_PROMPT` - any special instructions the model may need to take into account beyond your user preferences. defaults to 'you are a helpful assistant'
+4. `ENABLED_CLIENTS` - an array of strings containing the names of the MCP servers you want the system to have access to. Make sure they are the same names as those used in the `mcp_clients/` implementations. This will allow you to omit, for example, outlook, and still have the system run without issue
 
 Then run `python plan_exec_agent.py` to see the result
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This will generate a daily briefing from a sources. You do not need to install them all, the code will run without them all installed but their tools will not be accessible. The instructions for all of them are below.
 
-## How to install and run
+## How to install before running
 
-1. `pip install -r requirements.txt`
+1. create a python venv then `pip install -r requirements.txt`
 2. You need to `git  clone` the following repos and run `npm install` in all the project roots
     - https://github.com/nspady/google-calendar-mcp
     - https://github.com/GongRzhe/Gmail-MCP-Server
@@ -53,21 +53,41 @@ SLACK_USER_TOKEN=
 
 **Note** the unusual setup for the _Notion Token_ under `OPENAPI_MCP_HEADERS`
 
-If you want observability and tracing, set these environmen variables too
+### Observability and tracing
+This project uses [Langfuse](https://github.com/langfuse/langfuse) for observability and tracing. Its not mandatory but its helpful to see the dozens of LLM calls that occur nicely formatted in a UI. To utilize it, set these environment variables in the `.env`:
 
 ```
 LANGFUSE_SECRET_KEY=
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_HOST="https://cloud.langfuse.com"
 ```
-12. To utilize the default daily briefing flow, create a Notion page called `Daily Briefings`. Ideally this should be at the root of your Notion workspace.   
-You can utilize other names, but update the `variables` at the top of `main` in `host.py`. 
-13. Update the `user_context` in `main` in `plan_exec_agent.py` with a description of who you are, how you like to work (like what communication tools you prefer) and any extra information that will make the model's output better. Update the `base_system_prompt` with any special instructions you want it to take into account. 
-14. The instructions for the LLM on *how* to generate the daily briefing are in the  `query` variable in `plan_exec_agent.py` in the `main` method. Change the step-by-step instructions based on how you want you daily briefing created.  
+
+## How to Run
+The MCP Assistant application is heavily customizable. You can do anything email triaging to lead qualification.
+
+The default workflow generates a **daily briefing** over various tools like email, calendar, whatsapp and Notion that tells you your schedule for the day, gives you background research from the internet about who you're meeting with and tells you what is urgent. 
+
+### Run the Default Flow - Daily Briefing in Notion
+1. Create a Notion page called `Daily Briefings`. Ideally this should be at the root of your Notion workspace.   
+2. Update the `user_context` in `main` in `plan_exec_agent.py` with a description of who you are, how you like to work (like what communication tools you prefer) and any extra information that will make the model's output better. Update the `base_system_prompt` with any special instructions you want it to take into account. 
+3. The instructions for the LLM on *how* to generate the daily briefing are in the  `query` variable in `plan_exec_agent.py` in the `main` method. Change the step-by-step instructions based on how you want you daily briefing created.  
 For example, if you want the briefing to also check a specific Notion page that has your tasks, the model can also do this
-15. run `python plan_exec_agent.py` to create a daily briefing one time. 
+4. run `python plan_exec_agent.py` to create a daily briefing one time. 
+
+### Run your own Custom Flow
+Create a file called `user_inputs.py` in root directory then add the following constant variables that will control how the assistant runs:
+1. `QUERY` - your request for the MCP assistant
+2. `USER_CONTEXT` - background information on who you are, what your preferences are, how you like to work, etc. Helps the model produce better output
+3. `BASE_SYSTEM_PROMPT` - any special instructions the model may need to take into account beyond your user preferences. defaults to 'you are a helpful assistant'
+
+Then run `python plan_exec_agent.py` to see the result
 
 ## Future Work
 
 - More connectors
-- Script to run the briefing automatically at the same time every day
+- Script to run the briefing automatically at the same time every day as a background process
+- Fix asyncio log pollution
+- Make sure the agent can iterate over every item for a given task (i.e. all 50 emails in an inbox, rather than only the first 10)
+- Save the execution graph after a successful run and load it next time instead of regenerating it
+- Context window reduction mechanism / token limiting to save money
+- Configurability for different models at different steps - planning vs. executing, cheap vs. expensive

--- a/host.py
+++ b/host.py
@@ -642,10 +642,6 @@ async def main():
             BASE_SYSTEM_PROMPT = user_inputs.BASE_SYSTEM_PROMPT
         if hasattr(user_inputs, 'USER_CONTEXT'):
             USER_CONTEXT = user_inputs.USER_CONTEXT
-        if hasattr(user_inputs, 'DATE'):
-            DATE = user_inputs.DATE
-        if hasattr(user_inputs, 'NOTION_PAGE_TITLE'):
-            NOTION_PAGE_TITLE = user_inputs.NOTION_PAGE_TITLE
     except ImportError:
         print("Unable to load values from user_inputs.py found, using default values")
 
@@ -657,7 +653,7 @@ async def main():
 
     try:
         await host.initialize_mcp_clients()
-        result = await host.process_input_with_agent_loop(QUERY, LANGFUSE_SESSION_ID)
+        result = await host.process_input_with_agent_loop(QUERY, langfuse_session_id=LANGFUSE_SESSION_ID)
         print(result)
     finally:
         await host.cleanup()

--- a/host.py
+++ b/host.py
@@ -602,14 +602,14 @@ class MCPHost:
 async def main():
     """
     This creates a sample daily briefing for today from my gmail and google calendar then writes it to a Notion database.
-    Override these variables OR the `query` to customize the daily briefing to your liking.
+    Configuration can be customized in user_inputs.py, or will use defaults if not found.
     """
-    # variables
+    # NOTE: the are Default values you can override in user_inputs.py
     DATE = datetime.today().strftime("%Y-%m-%d")
     NOTION_PAGE_TITLE = "Daily Briefings"
     LANGFUSE_SESSION_ID = datetime.today().strftime("%Y-%m-%d %H:%M:%S")
-
-    user_context = """
+    
+    USER_CONTEXT = """
     I am David, the CTO / Co-Founder of a pre-seed startup based in San Francisco. 
     I handle all the coding and product development.
     We are a two person team, with my co-founder handling sales, marketing, and business development.
@@ -617,29 +617,47 @@ async def main():
     When looking at my calendar, if you see anything titled 'b', that means it's a blocker.
     I often put blockers before or after calls that could go long.
     """
-
-    base_system_prompt = f"""
-    You are a helpful assistant. 
+    
+    BASE_SYSTEM_PROMPT = """
+    You are a helpful assistant.
+    """
+    
+    QUERY = f"""
+    Your goal is to create a daily briefing for today, {DATE}, from my gmail and google calendar.
+    Do the following:
+    1) check my gmail, look for unread emails and tell me if any are high priority
+    2) check my google calendar, look for events from today and give me a summary of the events. 
+    3) Go to my second email, which is my outlook account, and look for any unread emails. Write a summary of the unread emails.
+    4) Write the output from the above steps into a new page in my Notion in the '{NOTION_PAGE_TITLE}' page. Title the entry '{DATE}', which is today's date. 
     """
 
+    # Try to import user configurations, override defaults if found
+    try:
+        print("Loading values from user_inputs.py")
+        import user_inputs
+        # Override each value individually if it exists in user_inputs
+        if hasattr(user_inputs, 'QUERY'):
+            QUERY = user_inputs.QUERY
+        if hasattr(user_inputs, 'BASE_SYSTEM_PROMPT'):
+            BASE_SYSTEM_PROMPT = user_inputs.BASE_SYSTEM_PROMPT
+        if hasattr(user_inputs, 'USER_CONTEXT'):
+            USER_CONTEXT = user_inputs.USER_CONTEXT
+        if hasattr(user_inputs, 'DATE'):
+            DATE = user_inputs.DATE
+        if hasattr(user_inputs, 'NOTION_PAGE_TITLE'):
+            NOTION_PAGE_TITLE = user_inputs.NOTION_PAGE_TITLE
+    except ImportError:
+        print("Unable to load values from user_inputs.py found, using default values")
+
     # Initialize host with default system prompt
-    host = MCPHost(default_system_prompt=base_system_prompt, user_context=user_context)
+    host = MCPHost(
+        default_system_prompt=BASE_SYSTEM_PROMPT,
+        user_context=USER_CONTEXT
+    )
 
     try:
         await host.initialize_mcp_clients()
-
-        # can override the query to customize the daily briefing to your liking
-        # NOTE: provide the model with step by step instructions for best results
-        query = f"""
-        Your goal is to create a daily briefing for today, {DATE}, from my gmail and google calendar.
-        Do the following:
-        1) check my gmail, look for unread emails and tell me if any are high priority
-        2) check my google calendar, look for events from today and give me a summary of the events. 
-           - If I have a meeting with anyone, search the internet for that person and write a quick summary of them.
-        3) Go to my second email, which is my outlook account, and look for any unread emails. Write a summary of the unread emails.
-        4) Write the output from the above steps into a new page in my Notion in the '{NOTION_PAGE_TITLE}' page. Title the entry '{DATE}', which is today's date. 
-        """
-        result = await host.process_input_with_agent_loop(query, LANGFUSE_SESSION_ID)
+        result = await host.process_input_with_agent_loop(QUERY, LANGFUSE_SESSION_ID)
         print(result)
     finally:
         await host.cleanup()

--- a/host.py
+++ b/host.py
@@ -29,7 +29,7 @@ class MCPHost:
         self.exa_client = ExaMCPClient()
         self.outlook_client = OutlookMCPClient()
         self.slack_client = SlackMCPClient()
-        
+
         # inject the user context into the system prompt if its provided
         if default_system_prompt and user_context:
             default_system_prompt = f"""
@@ -38,7 +38,7 @@ class MCPHost:
             USER CONTEXT:
             {user_context}
             """
-        
+
         # Store system prompt as instance variable with a default
         self.system_prompt = default_system_prompt or "You are a helpful assistant."
         self.user_context = user_context if user_context else ""
@@ -188,8 +188,15 @@ class MCPHost:
         # Store the map in the class for later use
         self.tool_to_client_map = tool_to_client_map
         return tools, tool_to_client_map
+
     @observe()
-    async def process_input_with_agent_loop(self, query: str, system_prompt: str = None, langfuse_session_id: str = None, state: Dict = None):
+    async def process_input_with_agent_loop(
+        self,
+        query: str,
+        system_prompt: str = None,
+        langfuse_session_id: str = None,
+        state: Dict = None,
+    ):
         # Use provided system prompt or fall back to the instance variable
         current_system_prompt = (
             system_prompt if system_prompt is not None else self.system_prompt
@@ -272,7 +279,7 @@ class MCPHost:
         # Add a line at the end, before returning the result
         if state is not None and "tool_results" in state:
             state["tool_results"].update(tool_results_context)
-        
+
         return "\n".join(final_text)
 
     async def _prepare_query(self, query: str) -> str:
@@ -291,7 +298,7 @@ class MCPHost:
         langfuse_context.update_current_observation(
             input=messages,
             model="claude-3-5-sonnet-20241022",
-            session_id=langfuse_session_id
+            session_id=langfuse_session_id,
         )
 
         response = self.anthropic.messages.create(
@@ -306,13 +313,13 @@ class MCPHost:
         if langfuse_session_id:
             langfuse_context.update_current_trace(session_id=langfuse_session_id)
             langfuse_context.flush()
-        
+
             # Add cost tracking
             langfuse_context.update_current_observation(
                 usage_details={
                     "input": response.usage.input_tokens,
                     "output": response.usage.output_tokens,
-                    "cache_read_input_tokens": response.usage.cache_read_input_tokens
+                    "cache_read_input_tokens": response.usage.cache_read_input_tokens,
                 }
             )
 
@@ -338,7 +345,7 @@ class MCPHost:
             langfuse_context.update_current_observation(name=tool_name)
             langfuse_context.update_current_trace(session_id=langfuse_session_id)
             langfuse_context.flush()
-  
+
         if tool_name == "reference_tool_output":
             return await self._handle_reference_tool(
                 tool_id,
@@ -571,13 +578,13 @@ class MCPHost:
         print("\n=== Initial Claude Response Analysis ===")
         text_outputs = [c for c in response.content if c.type == "text"]
         tool_calls = [c for c in response.content if c.type == "tool_use"]
-        
+
         # Log text outputs
         if text_outputs:
             print(f"\n📝 Text Outputs ({len(text_outputs)}):")
             for i, text in enumerate(text_outputs, 1):
                 print(f"  Output {i}: {text.text}")
-        
+
         # Log tool calls
         if tool_calls:
             print(f"\n🔧 Tool Calls ({len(tool_calls)}):")
@@ -588,8 +595,8 @@ class MCPHost:
                 print("    Input Arguments:")
                 for key, value in tool.input.items():
                     print(f"      {key}: {value}")
-        
-        print("\n" + "="*40 + "\n")
+
+        print("\n" + "=" * 40 + "\n")
 
 
 async def main():

--- a/mcp_clients/exa_client.py
+++ b/mcp_clients/exa_client.py
@@ -39,7 +39,9 @@ class ExaMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )
 
     async def cleanup(self):
         """Clean up resources"""

--- a/mcp_clients/gcal_client.py
+++ b/mcp_clients/gcal_client.py
@@ -39,7 +39,9 @@ class GCalMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )
 
     async def cleanup(self):
         """Clean up resources"""

--- a/mcp_clients/gmail_client.py
+++ b/mcp_clients/gmail_client.py
@@ -39,7 +39,9 @@ class GmailMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )
 
     async def cleanup(self):
         """Clean up resources"""

--- a/mcp_clients/notion_client.py
+++ b/mcp_clients/notion_client.py
@@ -38,4 +38,6 @@ class NotionMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )

--- a/mcp_clients/outlook_client.py
+++ b/mcp_clients/outlook_client.py
@@ -38,4 +38,6 @@ class OutlookMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )

--- a/mcp_clients/slack_client.py
+++ b/mcp_clients/slack_client.py
@@ -44,7 +44,10 @@ class SlackMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools:", [tool.name for tool in tools])
+        print(
+            f"\nConnected to server {self.name} with tools:",
+            [tool.name for tool in tools],
+        )
 
     async def cleanup(self):
         """Clean up resources"""

--- a/mcp_clients/whatsapp_client.py
+++ b/mcp_clients/whatsapp_client.py
@@ -52,4 +52,6 @@ class WhatsappMCPClient(MCPClient):
         # List available tools
         response = await self.session.list_tools()
         tools = response.tools
-        print(f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}")
+        print(
+            f"\nConnected to server {self.name} with tools: {[tool.name for tool in tools]}"
+        )

--- a/plan_exec_agent.py
+++ b/plan_exec_agent.py
@@ -579,10 +579,6 @@ async def main():
             BASE_SYSTEM_PROMPT = user_inputs.BASE_SYSTEM_PROMPT
         if hasattr(user_inputs, 'USER_CONTEXT'):
             USER_CONTEXT = user_inputs.USER_CONTEXT
-        if hasattr(user_inputs, 'DATE'):
-            DATE = user_inputs.DATE
-        if hasattr(user_inputs, 'NOTION_PAGE_TITLE'):
-            NOTION_PAGE_TITLE = user_inputs.NOTION_PAGE_TITLE
     except ImportError:
         print("Unable to load values from user_inputs.py found, using default values")
 

--- a/plan_exec_agent.py
+++ b/plan_exec_agent.py
@@ -20,6 +20,7 @@ class State(TypedDict):
 
 class Plan(BaseModel):
     """Plan to follow in future"""
+
     steps: List[str] = Field(
         description="different steps to follow, should be in sorted order"
     )
@@ -27,11 +28,13 @@ class Plan(BaseModel):
 
 class Response(BaseModel):
     """Response to user."""
+
     response: str
 
 
 class Act(BaseModel):
     """Action to perform."""
+
     action: Union[Response, Plan] = Field(
         description="Action to perform. If you want to respond to user, use Response. "
         "If you need to further use tools to get the answer, use Plan."
@@ -44,14 +47,14 @@ class PlanExecAgent:
 
     async def initialize_mcp_clients(self):
         await self.mcp_host.initialize_mcp_clients()
-        
+
         # NOTE: can remove this if we are recyling mcp_host.process_query
         await self.mcp_host.get_all_tools_from_servers()
 
     @observe()
     async def initial_plan(self, state: State) -> Plan:
         """Generate an initial plan based on the user's query."""
-        
+
         # hybrid of langgraph's prompt and our own
         plan_system_prompt = f"""
         You are a planning agent. Your task is to break down a complex query into a sequence of steps.
@@ -66,11 +69,11 @@ class PlanExecAgent:
 
         Use this context to inform your planning decisions. For example, prefer tools and approaches that align with the user's preferences and work environment.
         """
-        
+
         plan_prompt = f"""
         Create a detailed plan to accomplish the following objective:
         
-        {state['input']}
+        {state["input"]}
         
         Use the submit_plan tool to provide your plan as a list of steps.
         Each step should be clear and actionable by an agent with access to tools.
@@ -78,47 +81,56 @@ class PlanExecAgent:
 
         # Get shared planning tools
         planning_tools = self.get_planning_tools()
-        
+
         # Get available tools to inform the planning
         available_tools = await self.mcp_host.get_all_tools()
-        tool_descriptions = "\n".join([f"- {tool['name']}: {tool['description']}" for tool in available_tools])
-        plan_prompt += f"\n\nYou can use the following tools in your plan:\n{tool_descriptions}"
-        
+        tool_descriptions = "\n".join(
+            [f"- {tool['name']}: {tool['description']}" for tool in available_tools]
+        )
+        plan_prompt += (
+            f"\n\nYou can use the following tools in your plan:\n{tool_descriptions}"
+        )
+
         messages = [{"role": "user", "content": plan_prompt}]
 
-        # NOTE: we are not using the user-specific system prompt 
+        # NOTE: we are not using the user-specific system prompt
         response = await self.mcp_host._create_claude_message(
-            messages, [planning_tools["plan_tool"]], plan_system_prompt, state['langfuse_session_id']
+            messages,
+            [planning_tools["plan_tool"]],
+            plan_system_prompt,
+            state["langfuse_session_id"],
         )
 
         steps = []
-        
+
         for content in response.content:
             if content.type == "tool_use" and content.name == "submit_plan":
                 # Get the plan directly from the tool input
                 steps = content.input.get("plan", [])
                 break
-        
+
         # Fallback if no tool call was made (should be rare with good prompting)
         if not steps and response.content and response.content[0].type == "text":
-            print("Warning: Plan was returned as text rather than tool call. Attempting to parse...")
+            print(
+                "Warning: Plan was returned as text rather than tool call. Attempting to parse..."
+            )
             response_text = response.content[0].text
             steps = self.extract_plan_from_response(response_text)
-        
+
         # If something went wrong
         if not steps:
             steps = ["Error: Could not generate plan"]
-        
+
         # Return a Plan object instead of a list
         return Plan(steps=steps)
 
     @observe()
     async def execute_step(self, state: State) -> str:
         """Execute the first step from the current plan using the MCP clients."""
-        
+
         # Get the current step from the state
         step = state["current_plan"][0]
-        
+
         executor_system_prompt = f"""
         You are an execution agent tasked with carrying out a specific step in a plan.
         Your current task is to execute the following step: "{step}"
@@ -136,31 +148,37 @@ class PlanExecAgent:
         - Maintain a comprehensive summary that includes information from all items
         - Don't truncate or summarize too aggressively
         """
-        
+
         # TODO: not clear if we want to pass this context in
         # Create context for the execution, including past steps
         past_steps_context = ""
         if "past_steps" in state and state["past_steps"]:
             past_steps_context = "## Previous steps that have been completed:\n"
             for i, (past_step, result) in enumerate(state["past_steps"]):
-                past_steps_context += f"{i+1}. Step: {past_step}\n   Result: {result}\n\n"
-        
+                past_steps_context += (
+                    f"{i + 1}. Step: {past_step}\n   Result: {result}\n\n"
+                )
+
         objective_context = f"## Your objective:\n{state['input']}\n\n"
-        plan_context = f"## Overall plan:\n" + "\n".join([f"{i+1}. {s}" for i, s in enumerate(state["current_plan"])]) + "\n\n"
-        
+        plan_context = (
+            f"## Overall plan:\n"
+            + "\n".join([f"{i + 1}. {s}" for i, s in enumerate(state["current_plan"])])
+            + "\n\n"
+        )
+
         execution_prompt = f"{objective_context}{plan_context}{past_steps_context}## Current step to execute:\n{step}\n\nPlease execute this step using the available tools."
-        
+
         tool_results = state.get("tool_results")
         if tool_results is None:
             state["tool_results"] = {}
 
         result = await self.mcp_host.process_input_with_agent_loop(
-            execution_prompt, 
+            execution_prompt,
             system_prompt=executor_system_prompt,
-            langfuse_session_id=state['langfuse_session_id'],
-            state=state
+            langfuse_session_id=state["langfuse_session_id"],
+            state=state,
         )
-        
+
         # Extract the most relevant part of the result
         # NOTE: want want to remove if the performance is poor - too many tokens removed
         processed_result = self.extract_final_result(result)
@@ -170,10 +188,10 @@ class PlanExecAgent:
     async def replan(self, state: State) -> Act:
         """
         Update the plan based on the results of previous steps.
-        
+
         Args:
             state: The current state including input, initial plan, current plan, and past steps
-        
+
         Returns:
             Act object with either a new Plan or a Response to the user
         """
@@ -195,15 +213,19 @@ class PlanExecAgent:
 
         Use this context to inform your planning decisions. For example, prefer tools and approaches that align with the user's preferences and work environment.
         """
-        
+
         # Create context for replanning
         past_steps_context = "## Steps that have been completed:\n"
         for i, (past_step, result) in enumerate(state["past_steps"]):
-            past_steps_context += f"{i+1}. Step: {past_step}\n   Result: {result}\n\n"
-        
+            past_steps_context += f"{i + 1}. Step: {past_step}\n   Result: {result}\n\n"
+
         # only use current plan, not initial plan
-        current_plan_context = "## Current plan:\n" + "\n".join([f"{i+1}. {s}" for i, s in enumerate(state["current_plan"])]) + "\n\n"
-        
+        current_plan_context = (
+            "## Current plan:\n"
+            + "\n".join([f"{i + 1}. {s}" for i, s in enumerate(state["current_plan"])])
+            + "\n\n"
+        )
+
         tool_context = ""
         if "tool_results" in state and state["tool_results"]:
             tool_context = "## Data available from previous steps:\n"
@@ -216,7 +238,7 @@ class PlanExecAgent:
         # NOTE: the context window could get very large here
         replan_prompt = f"""
         ## Objective:
-        {state['input']}
+        {state["input"]}
         
         {current_plan_context}
         {past_steps_context}
@@ -226,17 +248,17 @@ class PlanExecAgent:
         1. Continue with an updated plan (use submit_plan tool if there are still steps needed)
         2. Provide a final response (use submit_final_response tool if the objective has been achieved)
         """
-        
+
         # Get shared planning tools
         planning_tools = self.get_planning_tools()
         replan_tools = [planning_tools["plan_tool"], planning_tools["response_tool"]]
-        
+
         messages = [{"role": "user", "content": replan_prompt}]
-        
+
         response = await self.mcp_host._create_claude_message(
-            messages, replan_tools, replan_system_prompt, state['langfuse_session_id']
+            messages, replan_tools, replan_system_prompt, state["langfuse_session_id"]
         )
-        
+
         # Process the response to determine the action
         for content in response.content:
             if content.type == "tool_use":
@@ -246,21 +268,24 @@ class PlanExecAgent:
                 elif content.name == "submit_final_response":
                     final_response = content.input.get("response", "")
                     return Act(action=Response(response=final_response))
-        
+
         # Fallback if no tool call was made
         if response.content and response.content[0].type == "text":
             response_text = response.content[0].text
             # Check if it seems like a final response
-            if "objective has been achieved" in response_text.lower() or "final response" in response_text.lower():
+            if (
+                "objective has been achieved" in response_text.lower()
+                or "final response" in response_text.lower()
+            ):
                 return Act(action=Response(response=response_text))
             else:
                 # Try to extract steps
                 steps = self.extract_plan_from_response(response_text)
                 return Act(action=Plan(steps=steps))
-        
+
         # Default fallback
         return Act(action=Plan(steps=state["current_plan"]))
-    
+
     async def cleanup(self):
         """Clean up resources."""
         await self.mcp_host.cleanup()
@@ -269,52 +294,58 @@ class PlanExecAgent:
         """
         Extract a plan (list of steps) from Claude's response text.
         Handles various formats including JSON, markdown lists, and numbered lists.
-        
+
         Args:
             response_text: The text response from Claude
-            
+
         Returns:
             List[str]: A list of steps extracted from the response
         """
         import json
         import re
-        
+
         # First try to find and parse JSON
-        json_pattern = r'(\[[\s\S]*?\]|\{[\s\S]*?\})'
+        json_pattern = r"(\[[\s\S]*?\]|\{[\s\S]*?\})"
         json_matches = re.findall(json_pattern, response_text)
-        
+
         for json_str in json_matches:
             try:
                 # Try parsing as JSON array
                 parsed = json.loads(json_str)
-                if isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+                if isinstance(parsed, list) and all(
+                    isinstance(item, str) for item in parsed
+                ):
                     return parsed
                 # Try parsing as JSON object with "steps" key
-                elif isinstance(parsed, dict) and "steps" in parsed and isinstance(parsed["steps"], list):
+                elif (
+                    isinstance(parsed, dict)
+                    and "steps" in parsed
+                    and isinstance(parsed["steps"], list)
+                ):
                     return parsed["steps"]
             except json.JSONDecodeError:
                 continue
-        
+
         # If JSON parsing fails, look for markdown or numbered lists
         steps = []
-        
+
         # Try to find markdown list items (- item or * item)
-        markdown_pattern = r'[\-\*]\s*(.*?)(?=\n[\-\*]|\n\n|\n$|$)'
+        markdown_pattern = r"[\-\*]\s*(.*?)(?=\n[\-\*]|\n\n|\n$|$)"
         markdown_matches = re.findall(markdown_pattern, response_text)
         if markdown_matches:
             return [step.strip() for step in markdown_matches if step.strip()]
-        
+
         # Try to find numbered list items (1. item, 2. item, etc.)
-        numbered_pattern = r'\d+\.\s*(.*?)(?=\n\d+\.|\n\n|\n$|$)'
+        numbered_pattern = r"\d+\.\s*(.*?)(?=\n\d+\.|\n\n|\n$|$)"
         numbered_matches = re.findall(numbered_pattern, response_text)
         if numbered_matches:
             return [step.strip() for step in numbered_matches if step.strip()]
-        
+
         # If all else fails, split by newlines and filter out empty lines
-        lines = [line.strip() for line in response_text.split('\n') if line.strip()]
+        lines = [line.strip() for line in response_text.split("\n") if line.strip()]
         if lines:
             return lines
-        
+
         # If nothing worked, return empty list
         return []
 
@@ -330,11 +361,11 @@ class PlanExecAgent:
                         "plan": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Array of strings where each string is a step in the plan"
+                            "description": "Array of strings where each string is a step in the plan",
                         }
                     },
-                    "required": ["plan"]
-                }
+                    "required": ["plan"],
+                },
             },
             "response_tool": {
                 "name": "submit_final_response",
@@ -344,104 +375,107 @@ class PlanExecAgent:
                     "properties": {
                         "response": {
                             "type": "string",
-                            "description": "Final response to the user"
+                            "description": "Final response to the user",
                         }
                     },
-                    "required": ["response"]
-                }
-            }
+                    "required": ["response"],
+                },
+            },
         }
 
     def extract_final_result(self, text: str) -> str:
         """
         Extract the final RESULT section from the text if present, otherwise return the original text.
         This is to eliminate the repetition of intermediate results added to the `final_text` array
-        inside the mcp_host.process_query function. 
+        inside the mcp_host.process_query function.
         We care only about storing the final result of the step in the past_steps array, not the intermediate results.
         """
         import re
+
         # Find all RESULT: sections
-        result_sections = re.findall(r'RESULT:(.*?)(?=RESULT:|$)', text, re.DOTALL)
-        
+        result_sections = re.findall(r"RESULT:(.*?)(?=RESULT:|$)", text, re.DOTALL)
+
         if result_sections:
             # Return the last (most complete) RESULT section
             return result_sections[-1].strip()
         else:
-            # If no RESULT sections found, return the original text 
+            # If no RESULT sections found, return the original text
             # but try to clean up a bit by removing tool call logs
-            cleaned_text = re.sub(r'\[Calling tool.*?\]', '', text)
+            cleaned_text = re.sub(r"\[Calling tool.*?\]", "", text)
             return cleaned_text.strip()
 
     @observe(as_type="trace")
     async def execute_plan(self, query: str, max_iterations: int = 25) -> str:
         """
         Execute a complete plan for the given query.
-        
+
         This method orchestrates the entire plan-execute-replan cycle:
         1. Creates an initial plan based on the query
         2. Executes steps one by one
         3. Replans after each step
         4. Returns the final response when done
-        
+
         Args:
             query: The user's query to process
             max_iterations: Maximum number of execution steps to run
-        
+
         Returns:
             The final response to the user's query
         """
         # Initialize state with values needed for the entire lifecycle
         state = {
-            'input': query,
-            'langfuse_session_id': datetime.today().strftime("%Y-%m-%d %H:%M:%S"),
-            'past_steps': [],
-            'current_plan': [],
-            'tool_results': {},
-            'initial_plan': [],
-            'response': ''
+            "input": query,
+            "langfuse_session_id": datetime.today().strftime("%Y-%m-%d %H:%M:%S"),
+            "past_steps": [],
+            "current_plan": [],
+            "tool_results": {},
+            "initial_plan": [],
+            "response": "",
         }
-        
+
         # Step 1: Generate the initial plan
         print(f"Generating initial plan for query: {query}")
         plan = await self.initial_plan(state)
-        state['initial_plan'] = plan.steps
-        state['current_plan'] = plan.steps.copy()
+        state["initial_plan"] = plan.steps
+        state["current_plan"] = plan.steps.copy()
         print(f"Initial plan generated with {len(plan.steps)} steps")
-        
+
         # Step 2-4: Execute steps, replan, and repeat
         iteration = 0
-        
-        while iteration < max_iterations and state['current_plan']:
+
+        while iteration < max_iterations and state["current_plan"]:
             iteration += 1
             print(f"\n==== Iteration {iteration}/{max_iterations} ====")
-            
+
             # Execute the next step in the plan
-            current_step = state['current_plan'][0]
+            current_step = state["current_plan"][0]
             print(f"Executing step: {current_step}")
-            
+
             result = await self.execute_step(state)
             print(f"Step execution completed")
-            
+
             # Update past_steps with the completed step and its result
-            state['past_steps'].append((current_step, result))
-            
+            state["past_steps"].append((current_step, result))
+
             # If we still have steps left or just completed the last one, replan
             print("Replanning based on execution results")
             replan_result = await self.replan(state)
-            
+
             # Process the replanning result
             if isinstance(replan_result.action, Response):
                 # We have a final response, we're done
                 print("Plan completed with final response")
-                state['response'] = replan_result.action.response
+                state["response"] = replan_result.action.response
                 break
             elif isinstance(replan_result.action, Plan):
                 # Update the entire plan with the new plan (not just removing completed step)
-                print(f"Plan updated, new step count: {len(replan_result.action.steps)}")
-                state['current_plan'] = replan_result.action.steps
-                
+                print(
+                    f"Plan updated, new step count: {len(replan_result.action.steps)}"
+                )
+                state["current_plan"] = replan_result.action.steps
+
                 # If the updated plan is empty, we're done
-                if not state['current_plan']:
+                if not state["current_plan"]:
                     print("Plan completed (no more steps)")
                     # Generate a final response based on results
                     final_response_prompt = f"""
@@ -450,21 +484,29 @@ class PlanExecAgent:
                     
                     ## Steps completed:
                     """
-                    for i, (step, result) in enumerate(state['past_steps']):
-                        final_response_prompt += f"{i+1}. {step}\n   Result: {result}\n\n"
-                    
-                    final_response_prompt += "Please provide a final summary of what was accomplished."
-                    
-                    state['response'] = await self.mcp_host.process_input_with_agent_loop(
+                    for i, (step, result) in enumerate(state["past_steps"]):
+                        final_response_prompt += (
+                            f"{i + 1}. {step}\n   Result: {result}\n\n"
+                        )
+
+                    final_response_prompt += (
+                        "Please provide a final summary of what was accomplished."
+                    )
+
+                    state[
+                        "response"
+                    ] = await self.mcp_host.process_input_with_agent_loop(
                         final_response_prompt,
-                        langfuse_session_id=state['langfuse_session_id']
+                        langfuse_session_id=state["langfuse_session_id"],
                     )
                     break
-        
+
         # Check if we hit the iteration limit
-        if iteration >= max_iterations and state['current_plan']:
-            print(f"⚠️ Max iterations ({max_iterations}) reached without completing the plan")
-            
+        if iteration >= max_iterations and state["current_plan"]:
+            print(
+                f"⚠️ Max iterations ({max_iterations}) reached without completing the plan"
+            )
+
             # Generate a partial response
             incomplete_response_prompt = f"""
             ## Objective:
@@ -472,22 +514,26 @@ class PlanExecAgent:
             
             ## Steps completed ({iteration}/{max_iterations}, plan not completed):
             """
-            for i, (step, result) in enumerate(state['past_steps']):
-                incomplete_response_prompt += f"{i+1}. {step}\n   Result: {result}\n\n"
-            
-            incomplete_response_prompt += f"## Remaining steps ({len(state['current_plan'])} steps):\n"
-            for i, step in enumerate(state['current_plan']):
-                incomplete_response_prompt += f"{i+1}. {step}\n"
-            
-            incomplete_response_prompt += "\nPlease provide a summary of progress made and what remains to be done."
-            
-            state['response'] = await self.mcp_host.process_input_with_agent_loop(
-                incomplete_response_prompt,
-                langfuse_session_id=state['langfuse_session_id']
+            for i, (step, result) in enumerate(state["past_steps"]):
+                incomplete_response_prompt += (
+                    f"{i + 1}. {step}\n   Result: {result}\n\n"
+                )
+
+            incomplete_response_prompt += (
+                f"## Remaining steps ({len(state['current_plan'])} steps):\n"
             )
-        
+            for i, step in enumerate(state["current_plan"]):
+                incomplete_response_prompt += f"{i + 1}. {step}\n"
+
+            incomplete_response_prompt += "\nPlease provide a summary of progress made and what remains to be done."
+
+            state["response"] = await self.mcp_host.process_input_with_agent_loop(
+                incomplete_response_prompt,
+                langfuse_session_id=state["langfuse_session_id"],
+            )
+
         # Return the final response
-        return state['response']
+        return state["response"]
 
 
 async def main():
@@ -513,7 +559,9 @@ async def main():
     """
 
     # Initialize host with default system prompt
-    host = PlanExecAgent(default_system_prompt=base_system_prompt, user_context=user_context)
+    host = PlanExecAgent(
+        default_system_prompt=base_system_prompt, user_context=user_context
+    )
 
     try:
         await host.initialize_mcp_clients()

--- a/plan_exec_agent.py
+++ b/plan_exec_agent.py
@@ -42,14 +42,11 @@ class Act(BaseModel):
 
 
 class PlanExecAgent:
-    def __init__(self, default_system_prompt: str = None, user_context: str = None):
-        self.mcp_host = MCPHost(default_system_prompt, user_context)
+    def __init__(self, default_system_prompt: str = None, user_context: str = None, enabled_clients: List[str] = None):
+        self.mcp_host = MCPHost(default_system_prompt, user_context, enabled_clients)
 
     async def initialize_mcp_clients(self):
         await self.mcp_host.initialize_mcp_clients()
-
-        # NOTE: can remove this if we are recyling mcp_host.process_query
-        await self.mcp_host.get_all_tools_from_servers()
 
     @observe()
     async def initial_plan(self, state: State) -> Plan:
@@ -579,13 +576,19 @@ async def main():
             BASE_SYSTEM_PROMPT = user_inputs.BASE_SYSTEM_PROMPT
         if hasattr(user_inputs, 'USER_CONTEXT'):
             USER_CONTEXT = user_inputs.USER_CONTEXT
+        if hasattr(user_inputs, 'ENABLED_CLIENTS'):
+            ENABLED_CLIENTS = user_inputs.ENABLED_CLIENTS
+            print(f"System will run with only the following clients:\n{ENABLED_CLIENTS}\n\n")
+        else:
+            ENABLED_CLIENTS = None
     except ImportError:
         print("Unable to load values from user_inputs.py found, using default values")
 
     # Initialize host with system prompt and user context
     host = PlanExecAgent(
         default_system_prompt=BASE_SYSTEM_PROMPT,
-        user_context=USER_CONTEXT
+        user_context=USER_CONTEXT,
+        enabled_clients=ENABLED_CLIENTS
     )
 
     try:


### PR DESCRIPTION
### What
- add `user_context` to the plan-execute-agent's initial plan and replan workflows
- load user input query and user tool selection from an untracked file called `user_inputs.py`

### Verification
Generates the pages. **NOTE** that the `host.py` flow struggles to authenticate to Slack and its highly unpredictable how often it succeeds in writing to Notion

<img width="593" alt="image" src="https://github.com/user-attachments/assets/be369726-6f86-40a9-9ec4-7fcb2afc649e" />
