### PR TITLE
Upgrades to langfuse & arcade 

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,12 @@
 from datetime import datetime
 from src.plan_exec_agent import PlanExecAgent, ModelProvider, StepExecutor
 
-DEFAULT_CLIENTS = [
-    "Google Calendar",
-    "Gmail",
-    "Notion",
-    "Whatsapp",
-    "Exa",
-    "Outlook",
-    "Slack",
+DEFAULT_TOOLKITS = [
+    "google",
+    "slack",
+    "microsoft",
+    "github",
+    "notion"
 ]
 
 # NOTE: these are Default values you can override in user_inputs.py
@@ -50,16 +48,16 @@ try:
         BASE_SYSTEM_PROMPT = user_inputs.BASE_SYSTEM_PROMPT
     if hasattr(user_inputs, "USER_CONTEXT"):
         USER_CONTEXT = user_inputs.USER_CONTEXT
-    # if hasattr(user_inputs, "ENABLED_CLIENTS"):
-    #     ENABLED_CLIENTS = user_inputs.ENABLED_CLIENTS
-    #     print(
-    #         f"System will run with only the following clients:\n{ENABLED_CLIENTS}\n\n"
-    #     )
-    # else:
-    #     ENABLED_CLIENTS = DEFAULT_CLIENTS
+    if hasattr(user_inputs, "ENABLED_TOOLKITS"):
+        ENABLED_TOOLKITS = user_inputs.ENABLED_TOOLKITS
+        print(
+            f"System will run with only the following toolkits:\n{ENABLED_TOOLKITS}\n\n"
+        )
+    else:
+        ENABLED_TOOLKITS = DEFAULT_TOOLKITS
 except ImportError:
     print("Unable to load values from user_inputs.py found, using default values")
-    # ENABLED_CLIENTS = DEFAULT_CLIENTS
+    ENABLED_TOOLKITS = DEFAULT_TOOLKITS
 
 def main():
     """
@@ -70,7 +68,7 @@ def main():
     host = PlanExecAgent(
         default_system_prompt=BASE_SYSTEM_PROMPT,
         user_context=USER_CONTEXT,
-        #enabled_clients=ENABLED_CLIENTS,
+        enabled_toolkits=ENABLED_TOOLKITS
     )
 
     print(f"INPUT_ACTION: {INPUT_ACTION}")
@@ -93,7 +91,7 @@ def step_executor():
     executor = StepExecutor(
         default_system_prompt=BASE_SYSTEM_PROMPT,
         user_context=USER_CONTEXT,
-        # enabled_clients=ENABLED_CLIENTS,
+        enabled_toolkits=ENABLED_TOOLKITS,
     )
 
     result = executor.process_input_with_agent_loop(

--- a/main.py
+++ b/main.py
@@ -1,11 +1,10 @@
 from datetime import datetime
 from src.plan_exec_agent import PlanExecAgent, ModelProvider, StepExecutor
 
+# deliebrately omit Github and Microsoft during testing
 DEFAULT_TOOLKITS = [
     "google",
     "slack",
-    "microsoft",
-    "github",
     "notion"
 ]
 
@@ -73,7 +72,7 @@ def main():
 
     print(f"INPUT_ACTION: {INPUT_ACTION}")
 
-    result = host.execute_plan(INPUT_ACTION, provider=ModelProvider.ANTHROPIC)
+    result = host.execute_plan(INPUT_ACTION, provider=ModelProvider.OPENAI)
     print(result)
 
 

--- a/src/plan_exec_agent/arcade_utils.py
+++ b/src/plan_exec_agent/arcade_utils.py
@@ -1,9 +1,12 @@
 from arcadepy import Arcade
 from enum import Enum
+from typing import List
+
 
 class ModelProvider(Enum):
     ANTHROPIC = 'anthropic'
     OPENAI = 'openai'
+
 
 AVAILABLE_TOOLS = {
     "tools":
@@ -46,9 +49,11 @@ AVAILABLE_TOOLS = {
         "github",
         "slack",
         "microsoft",
-        "notion"
+        "notion",
+        "google"
     ]
 }
+
 
 def get_tools_from_arcade(arcade_client: Arcade, provider: ModelProvider):
     tools = []
@@ -58,5 +63,21 @@ def get_tools_from_arcade(arcade_client: Arcade, provider: ModelProvider):
     for tool_list in AVAILABLE_TOOLS["tools"].values():
         for tool in tool_list:
             tools.append(arcade_client.tools.formatted.get(name=tool, format=provider.value))
+
+    return tools
+
+
+def get_toolkits_from_arcade(arcade_client: Arcade, provider: ModelProvider, enabled_toolkits: List[str] = None):
+    if not enabled_toolkits:
+        return get_tools_from_arcade(arcade_client, provider)
+    
+    tools = []
+    for toolkit in enabled_toolkits:
+        if toolkit in AVAILABLE_TOOLS["toolkits"] and toolkit != "notion":
+            tools.extend(arcade_client.tools.formatted.list(toolkit=toolkit, format=provider.value))
+
+        elif toolkit == "notion":
+            for tool in AVAILABLE_TOOLS["tools"]["Notion"]:
+                tools.append(arcade_client.tools.formatted.get(name=tool, format=provider.value))
 
     return tools

--- a/src/plan_exec_agent/plan_exec_agent.py
+++ b/src/plan_exec_agent/plan_exec_agent.py
@@ -48,10 +48,10 @@ class PlanExecAgent:
         self,
         default_system_prompt: str = None,
         user_context: str = None,
-        enabled_clients: List[str] = None,
+        enabled_toolkits: List[str] = None,
     ):
         self.step_executor = StepExecutor(
-            default_system_prompt, user_context, enabled_clients
+            default_system_prompt, user_context, enabled_toolkits
         )
 
     @observe()
@@ -87,6 +87,8 @@ class PlanExecAgent:
 
         # Get available tools to inform the planning
         available_tools = self.step_executor.get_all_tools(state["provider"])
+        state["tools"] = available_tools
+        
         tool_descriptions = "\n".join(
             [f"- {name}: {description}" 
              for name, description in [self._get_tool_description(tool, state["provider"]) 

--- a/src/plan_exec_agent/plan_exec_agent.py
+++ b/src/plan_exec_agent/plan_exec_agent.py
@@ -106,7 +106,7 @@ class PlanExecAgent:
             messages,
             [planning_tools["plan_tool"]],
             plan_system_prompt,
-            state["langfuse_session_id"],
+            {"session_id": state["langfuse_session_id"], "user_id": state["user_id"]},
         )
 
         steps = self._extract_plan_from_response(response, state["provider"])
@@ -299,7 +299,7 @@ class PlanExecAgent:
             messages,
             replan_tools,
             replan_system_prompt,
-            state["langfuse_session_id"],
+            {"session_id": state["langfuse_session_id"], "user_id": state["user_id"]},
         )
 
         return self._process_replan_response(response, state)

--- a/src/plan_exec_agent/plan_exec_agent.py
+++ b/src/plan_exec_agent/plan_exec_agent.py
@@ -517,7 +517,8 @@ class PlanExecAgent:
         input_action: str,
         provider: ModelProvider = ModelProvider.ANTHROPIC,
         max_iterations: int = 25,
-        user_id: str = "david_test"
+        user_id: str = "david_test",
+        langfuse_session_id: str = None
     ) -> str:
         """
         Execute a complete plan for the given query.
@@ -535,10 +536,12 @@ class PlanExecAgent:
         Returns:
             The final response to the user's query
         """
+        langfuse_session_id = langfuse_session_id or datetime.today().strftime("%Y-%m-%d %H:%M:%S")
+        
         # Initialize state with values needed for the entire lifecycle
         state = {
             "input": input_action,
-            "langfuse_session_id": datetime.today().strftime("%Y-%m-%d %H:%M:%S"),
+            "langfuse_session_id": langfuse_session_id,
             "past_steps": [],
             "current_plan": [],
             "tool_results": {},

--- a/src/plan_exec_agent/step_executor.py
+++ b/src/plan_exec_agent/step_executor.py
@@ -117,6 +117,11 @@ class StepExecutor:
         langfuse_session_id: str = None,
         state: Dict = None,
     ):
+        """
+        Process the input with the agent loop.
+
+        NOTE: we pass in the langfuse_session_id separately in case there is not a state
+        """
         current_system_prompt = (
             system_prompt if system_prompt is not None else self.system_prompt
         )
@@ -138,7 +143,7 @@ class StepExecutor:
             messages=messages,
             available_tools=available_tools,
             system_prompt=current_system_prompt,
-            langfuse_session_id=langfuse_session_id,
+            langfuse_data={"session_id": langfuse_session_id, "user_id": user_id},
         )
 
         final_text = []
@@ -189,7 +194,7 @@ class StepExecutor:
                         final_text,
                         user_id,
                         provider,
-                        langfuse_session_id,
+                        langfuse_data={"session_id": langfuse_session_id, "user_id": user_id},
                     )
 
                     # Update conversation context
@@ -203,7 +208,7 @@ class StepExecutor:
                         messages=messages,
                         available_tools=available_tools,
                         system_prompt=current_system_prompt,
-                        langfuse_session_id=langfuse_session_id,
+                        langfuse_data={"session_id": langfuse_session_id, "user_id": user_id},
                     )
 
                     # Break the content loop to process the new response

--- a/src/plan_exec_agent/tool_processor.py
+++ b/src/plan_exec_agent/tool_processor.py
@@ -24,7 +24,7 @@ class ToolProcessor:
         final_text: List[str],
         user_id: str,
         provider: ModelProvider,
-        langfuse_session_id: str = None,
+        langfuse_data: Dict[str, Any] = None,
     ) -> Tuple[List[Dict[str, Any]], Any]:
         """
         Process a specific tool call and return updated messages and result content.
@@ -34,9 +34,9 @@ class ToolProcessor:
         """
 
         # Add langfuse tracking
-        if langfuse_session_id:
+        if langfuse_data and "session_id" in langfuse_data and "user_id" in langfuse_data:
             langfuse_context.update_current_observation(name=tool_name)
-            langfuse_context.update_current_trace(session_id=langfuse_session_id)
+            langfuse_context.update_current_trace(session_id=langfuse_data["session_id"], user_id=langfuse_data["user_id"])
             langfuse_context.flush()
 
         if tool_name == "reference_tool_output":


### PR DESCRIPTION
## What
- Reworked logic that loads the tools data from Arcade to prevent spamming their API and hitting rate limits
- Wired up the `enabled_toolkits` so that the user can tell the agent to only work with tools it has authenticated already
- Made langfuse more configurable by enabling passing in the `langfuse_session_id` to the root `execute_plan` method and added the `user_id` to make it more searchable in the console

## Verification
Can see the end to end flow works after upgrades
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/80c631f8-3dd5-4afe-84a3-219544035f0a" />

Can see the user_id shows up in langfuse for Anthropic

![image](https://github.com/user-attachments/assets/a5acaff5-9ec7-449f-838d-7529086885f3)

And for open AI

![image](https://github.com/user-attachments/assets/c90d3798-b556-406d-b16e-295c589eacd0)

