### PR TITLE
added the option not to kick off an OAuth flow and block

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ OPENAI_API_KEY=
 ```
 You **only need ONE LLM key**. This repo only supports OpenAI and Anthropic models currently. 
 
+By default the agent will kick off an OAuth flow with Arcade for any tools that its not authorized to use. This will cause the exectuion to pause until that flow completes. If you want to skip any unauthorized tools without kicking off OAuth so that it doesn't block, set `SKIP_CLI_AUTH=true`.
+
 ### Observability and tracing
 This project uses [Langfuse](https://github.com/langfuse/langfuse) for observability and tracing. Its not mandatory but its helpful to see the dozens of LLM calls that occur nicely formatted in a UI. To utilize it, set these environment variables in the `.env`:
 

--- a/src/plan_exec_agent/plan_exec_agent.py
+++ b/src/plan_exec_agent/plan_exec_agent.py
@@ -247,6 +247,8 @@ class PlanExecAgent:
 
         Only add steps to the plan that still NEED to be done. Do not return previously done steps as part of the plan.
 
+        If a critical step fails 3 times in a row, determine that the task is failed and use the submit_final_response tool to respond to the user.
+
         USER CONTEXT:
         {self.step_executor.user_context}
 
@@ -528,7 +530,7 @@ class PlanExecAgent:
         This method orchestrates the entire plan-execute-replan cycle:
         1. Creates an initial plan based on the query
         2. Executes steps one by one
-        3. Replans after each step
+        3. Replans after each step. If a critical step in the plan fails 3 times in a row, the task is marked as failed.
         4. Returns the final response when done
 
         Args:


### PR DESCRIPTION
## What
Added a configuration, `SKIP_CLI_AUTH`, that will automatically fail a tool call that is unauthorized. By default, the system will block and wait for the user to complete the authentication and authorization via Arcade