### PR TITLE
David/fix replan skipping last step

### DIFF
--- a/src/plan_exec_agent/llm_utils.py
+++ b/src/plan_exec_agent/llm_utils.py
@@ -45,17 +45,23 @@ class LLMMessageCreator:
         # Add langfuse input tracking
         langfuse_context.update_current_observation(
             input=messages,
-            model="claude-3-5-sonnet-20241022",
+            model="claude-sonnet-4-20250514",
             session_id=langfuse_data["session_id"] if langfuse_data and "session_id" in langfuse_data else None
         )
 
-        response: Message = self.anthropic.messages.create(
-            model="claude-3-5-sonnet-20241022",
-            max_tokens=4096,
-            system=system_prompt,
-            messages=messages,
-            tools=available_tools,
-        )
+        # Prepare the API call parameters
+        api_params = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 4096,
+            "system": system_prompt,
+            "messages": messages,
+        }
+        
+        # Only add tools if they are provided and not None/empty
+        if available_tools:
+            api_params["tools"] = available_tools
+
+        response: Message = self.anthropic.messages.create(**api_params)
 
         # if no session id is provided, doesn't flush to langfuse
         if langfuse_data and "session_id" in langfuse_data and "user_id" in langfuse_data:

--- a/src/plan_exec_agent/plan_exec_agent.py
+++ b/src/plan_exec_agent/plan_exec_agent.py
@@ -180,7 +180,9 @@ class PlanExecAgent:
         You are an execution agent tasked with carrying out a specific step in a plan.
         Your current task is to execute the following step: "{step}"
         
-        You have access to tools to help you accomplish this task. Use these tools to complete the step.
+        You have access to tools to help you accomplish this task. You can use these tools to complete the step.
+        You have access to the results of previous tool calls performed earlier in the plan. You can use this information to complete the step.
+        You also have access to the results of previous steps. You can use this information to complete the step.
         Focus only on completing this specific step - do not attempt to execute other steps in the plan.
         
         IMPORTANT: If you retrieve data that will be needed by future steps (like email IDs, calendar events, etc.):
@@ -277,12 +279,12 @@ class PlanExecAgent:
 
         tool_context = ""
         if "tool_results" in state and state["tool_results"]:
-            tool_context = "## Data available from previous steps:\n"
-            for key, value in state["tool_results"].items():
+            tool_context = "## Data available from tool calls in previous steps:\n"
+            for key, (tool_name, value) in state["tool_results"].items():
                 if isinstance(value, list):
-                    tool_context += f"- {key}: {len(value)} items\n"
+                    tool_context += f"Tool name: {tool_name} - ID {key} (use this to reference the tool call): {len(value)} items\n"
                 else:
-                    tool_context += f"- {key}: Data available\n"
+                    tool_context += f"Tool name: {tool_name} - ID {key} (use this to reference the tool call): Data available\n"
 
         # NOTE: the context window could get very large here
         replan_prompt = f"""

--- a/src/plan_exec_agent/step_executor.py
+++ b/src/plan_exec_agent/step_executor.py
@@ -58,17 +58,13 @@ class StepExecutor:
         if provider == ModelProvider.ANTHROPIC:
             return {
                 "name": "reference_tool_output",
-                "description": "Reference the output of a previously called tool",
+                "description": "Reference the output of a previously called tool from any of the prior steps.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
                         "tool_id": {
                             "type": "string",
-                            "description": "The ID of the previously called tool",
-                        },
-                        "extract_path": {
-                            "type": "string",
-                            "description": "Optional JSON path to extract specific data from the tool result",
+                            "description": "The ID of the previously called tool. This is NOT the name of the tool, it is the ID of the tool call. ",
                         },
                     },
                     "required": ["tool_id"],
@@ -79,17 +75,13 @@ class StepExecutor:
                 "type": "function",
                 "function": {
                     "name": "reference_tool_output",
-                    "description": "Reference the output of a previously called tool",
+                    "description": "Reference the output of a previously called tool from any of the prior steps.",
                     "parameters": {
                         "type": "object",
                         "properties": {
                             "tool_id": {
                                 "type": "string",
-                                "description": "The ID of the previously called tool",
-                            },
-                            "extract_path": {
-                                "type": "string",
-                                "description": "Optional JSON path to extract specific data from the tool result",
+                                "description": "The ID of the previously called tool. This is NOT the name of the tool, it is the ID of the tool call. ",
                             },
                         },
                         "required": ["tool_id"],
@@ -100,11 +92,52 @@ class StepExecutor:
         else:
             raise ValueError(f"Unsupported provider: {provider}")
     
+    def _get_previous_step_tool(self, provider: ModelProvider):
+        """Tool to access results from previous steps in the plan."""
+        if provider == ModelProvider.ANTHROPIC:
+            return {
+                "name": "get_previous_step_result",
+                "description": "Get the result from a previous step in the plan. Use this when you need to reference what was accomplished in an earlier step. This is the output from the execution agent, not from a tool call.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "step_number": {
+                            "type": "integer",
+                            "description": "The step number (1-based) to get the result from. For example, use 1 for the first step, 2 for the second step, etc.",
+                            "minimum": 1
+                        },
+                    },
+                    "required": ["step_number"],
+                },
+            }
+        elif provider == ModelProvider.OPENAI:
+            return {
+                "type": "function",
+                "function": {
+                    "name": "get_previous_step_result",
+                    "description": "Get the result from a previous step in the plan. Use this when you need to reference what was accomplished in an earlier step. This is the output from the execution agent, not from a tool call.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "step_number": {
+                                "type": "integer",
+                                "description": "The step number (1-based) to get the result from. For example, use 1 for the first step, 2 for the second step, etc.",
+                                "minimum": 1
+                            },
+                        },
+                        "required": ["step_number"],
+                    },
+                }
+            }
+        else:
+            raise ValueError(f"Unsupported provider: {provider}")
+
     def get_all_tools(self, provider: ModelProvider):
-        # Add a tool reference capability that allows the LLM to reference previous tool outputs
+        # Add tools for referencing previous results
         reference_tool = self._get_reference_tool(provider)
+        previous_step_tool = self._get_previous_step_tool(provider)
         arcade_tools = get_toolkits_from_arcade(self.arcade_client, provider, self.enabled_toolkits)
-        return arcade_tools + [reference_tool]
+        return arcade_tools + [reference_tool, previous_step_tool]
 
     @observe()
     def process_input_with_agent_loop(
@@ -196,8 +229,8 @@ class StepExecutor:
 
                     # Update conversation context
                     messages = updated_messages
-                    if result_content:
-                        state["tool_results"][tool_id] = result_content
+                    if result_content and tool_name != "get_previous_step_result" and tool_name != "reference_tool_output":
+                        state["tool_results"][tool_id] = (tool_name, result_content)
                     
                     # Get next response
                     response = self.message_creator.create_message(

--- a/src/plan_exec_agent/tool_processor.py
+++ b/src/plan_exec_agent/tool_processor.py
@@ -88,7 +88,8 @@ class ToolProcessor:
         result_content = None
 
         if state and "tool_results" in state and referenced_tool_id in state["tool_results"]:
-            result_content = state["tool_results"][referenced_tool_id]
+            tool_name, result_content = state["tool_results"][referenced_tool_id]
+            print(f"Successfully retrieved tool result for {tool_name} with ID {referenced_tool_id} with LLM tool call {tool_id}")
         else:
             result_content = (
                 f"Error: No tool result found with ID '{referenced_tool_id}'"


### PR DESCRIPTION
## What
- Upgraded the prompting in `replan` to include a check for if the last step of the `current_plan` has been completed
- created `state['past_results']` to track whole outcomes of steps, the entire `final_text` array returned from the step executor. Added a tool to enable the model to retrieve these past results
- made `state['past_steps']` only store a 1-2 sentence summary as a result to reduce the context in the replan step by 7--80%

## Verification
Ran this test workflow, which was previously consistently skipping the last step of sending the slack message, even when explicitly told to do so, how to do so, and to verify

Prompt:
```
Your goal is to organize my inbox by triaging my emails. Please complete the following tasks:
1. Check my Gmail inbox for unarchived, unanswered, and unread emails. Identify any high priority items or todos. 
    1.1 Check my Gmail email address
2. Check each email and check if there are any important information
3. Check each email if it contains any urgent deadlines in the near future
4. Check each email if it is marketing spam, newsletter, fyis, or product updates and group it as not important
5. Make sure to send me a direct Slack message with the output and if there is no output send me a message telling me that there is no output
    5.1 Check my Slack username.
```
User context:
```
I like to categorise my emails by importance and urgency. 
Emails from my boss, customers and potential customers are important, emails that have a deadlines with action items are urgent. 
Payment notifications,Spam, newsletters, FYIs, marketing emails are usually not important.

my slack username: tonymolinari22
```


Can see here it succeeds twice in a row

<img width="801" alt="image" src="https://github.com/user-attachments/assets/44d65842-b618-4b38-8304-3f659d77a42b" />

<img width="757" alt="image" src="https://github.com/user-attachments/assets/78001cea-6bb0-404d-a903-99213ba7f196" />
