### PR TITLE
add redis publishing ability and task_id tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ Create a file called `user_inputs.py` in root directory then add the following c
 
 Then run `python main.py` to see the result
 
+### Linking the Results to Other Systems using a Queue
+This project supports publishing the `state` during the agent's main execution loop using Redis.
+
+
+**To run Redis locally, use:**
+```
+docker run -d --name redis-local -p 6379:6379 redis:latest
+```
+
+Please add the following environment variables to your .env file
+```
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_STREAM_NAME=plan_execution
+PUBLISH_TO_REDIS=true
+```
+
+If you need to debug redis, use the following REDIS CLI commands:
+First run this to start a terminal in the container `docker exec -it redis-local redis-cli`
+Then
+```
+KEYS * # check streams
+XLEN plan_execution # check this specific stream
+XREVRANGE plan_execution + - COUNT 1  # check the last message
+```
+
 ## Future Work
 
 - More connectors

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ docker run -d --name redis-local -p 6379:6379 redis:latest
 
 Please add the following environment variables to your .env file
 ```
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_DB=0
+REDIS_URL=redis://localhost:6379
 REDIS_STREAM_NAME=plan_execution
 PUBLISH_TO_REDIS=true
 ```
@@ -75,6 +73,7 @@ Then
 KEYS * # check streams
 XLEN plan_execution # check this specific stream
 XREVRANGE plan_execution + - COUNT 1  # check the last message
+docker exec redis-local redis-cli XTRIM plan_execution MAXLEN 0 # DELETE all messages on the stream - only use for cleanup during testing
 ```
 
 ## Future Work

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def main():
 
     print(f"INPUT_ACTION: {INPUT_ACTION}")
 
-    result = host.execute_plan(INPUT_ACTION, provider=ModelProvider.OPENAI)
+    result = host.execute_plan(INPUT_ACTION, provider=ModelProvider.OPENAI, task_id="testestesteststse")
     print(result)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pydantic-settings==2.8.1
 pydantic_core==2.33.1
 Pygments==2.19.1
 python-dotenv==1.1.0
+redis==6.1.0
 requests==2.32.3
 rich==14.0.0
 ruff==0.11.7

--- a/src/plan_exec_agent/redis_publisher.py
+++ b/src/plan_exec_agent/redis_publisher.py
@@ -1,0 +1,116 @@
+import json
+import os
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+# Add Redis import with optional handling
+try:
+    import redis
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+
+
+class RedisPublisher:
+    """Utility class for publishing plan execution events to Redis streams."""
+    
+    def __init__(self):
+        self._redis_client: Optional[redis.Redis] = None
+        if self._should_publish_to_redis():
+            self._init_redis_client()
+
+    def _should_publish_to_redis(self) -> bool:
+        """Check if Redis publishing is enabled via environment variable."""
+        return os.getenv("PUBLISH_TO_REDIS", "false").lower() in ("true", "1", "yes")
+
+    def _init_redis_client(self) -> None:
+        """Initialize Redis client for publishing."""
+        if not REDIS_AVAILABLE:
+            print("Warning: Redis not available. Install redis-py to enable publishing.")
+            return
+        
+        try:
+            redis_host = os.getenv("REDIS_HOST", "localhost")
+            redis_port = int(os.getenv("REDIS_PORT", "6379"))
+            redis_db = int(os.getenv("REDIS_DB", "0"))
+            
+            self._redis_client = redis.Redis(
+                host=redis_host,
+                port=redis_port,
+                db=redis_db,
+                decode_responses=True
+            )
+            # Test connection
+            self._redis_client.ping()
+            print(f"Redis client initialized successfully (host: {redis_host}:{redis_port})")
+        except Exception as e:
+            print(f"Failed to initialize Redis client: {e}")
+            self._redis_client = None
+
+    def _prepare_state_for_publishing(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Prepare state for Redis publishing by removing heavy/sensitive data.
+        
+        Args:
+            state: The full state dictionary
+            
+        Returns:
+            A cleaned state dictionary suitable for publishing
+        """
+        # Create a copy and remove heavy/sensitive keys
+        cleaned_state = state.copy()
+        
+        # Remove heavy data that could make the message too large
+        keys_to_remove = ["tool_results", "tools"]
+        for key in keys_to_remove:
+            cleaned_state.pop(key, None)
+        
+        # Convert any non-serializable objects to strings
+        if "provider" in cleaned_state:
+            cleaned_state["provider"] = str(cleaned_state["provider"])
+        
+        # Add timestamp for when this was published
+        cleaned_state["published_at"] = datetime.utcnow().isoformat()
+        
+        return cleaned_state
+
+    def publish_event(
+        self, 
+        event_type: str, 
+        state: Dict[str, Any],
+        stream_name: Optional[str] = None
+    ) -> None:
+        """
+        Publish state to Redis stream.
+        
+        Args:
+            event_type: Type of event (e.g., "initial_plan", "final_result")
+            state: State dictionary to publish
+            stream_name: Optional stream name override
+        """
+        try:
+            # Use provided stream name or default from env
+            stream_name = stream_name or os.getenv("REDIS_STREAM_NAME", "plan_execution")
+            
+            # Prepare the state for publishing
+            cleaned_state = self._prepare_state_for_publishing(state)
+            
+            # Create the message payload
+            message = {
+                "event_type": event_type,
+                "session_id": state.get("langfuse_session_id", "unknown"),
+                "user_id": state.get("user_id", "unknown"),
+                "task_id": state.get("task_id"),
+                "data": json.dumps(cleaned_state)
+            }
+            
+            # Publish to Redis stream
+            message_id = self._redis_client.xadd(stream_name, message)
+            print(f"Published {event_type} to Redis stream '{stream_name}' with ID: {message_id}")
+            
+        except Exception as e:
+            print(f"Failed to publish to Redis stream: {e}")
+
+    def is_enabled(self) -> bool:
+        """Check if Redis publishing is enabled and client is available."""
+        return self._should_publish_to_redis() and self._redis_client is not None

--- a/src/plan_exec_agent/redis_publisher.py
+++ b/src/plan_exec_agent/redis_publisher.py
@@ -30,19 +30,13 @@ class RedisPublisher:
             return
         
         try:
-            redis_host = os.getenv("REDIS_HOST", "localhost")
-            redis_port = int(os.getenv("REDIS_PORT", "6379"))
-            redis_db = int(os.getenv("REDIS_DB", "0"))
-            
-            self._redis_client = redis.Redis(
-                host=redis_host,
-                port=redis_port,
-                db=redis_db,
+            self._redis_client = redis.from_url(
+                os.getenv("REDIS_URL"),
                 decode_responses=True
             )
             # Test connection
             self._redis_client.ping()
-            print(f"Redis client initialized successfully (host: {redis_host}:{redis_port})")
+            print(f"Redis client initialized successfully (host: {os.getenv('REDIS_URL')})")
         except Exception as e:
             print(f"Failed to initialize Redis client: {e}")
             self._redis_client = None
@@ -82,6 +76,7 @@ class RedisPublisher:
     ) -> None:
         """
         Publish state to Redis stream.
+        NOTE: If any values are None, Redis will fail to publish
         
         Args:
             event_type: Type of event (e.g., "initial_plan", "final_result")


### PR DESCRIPTION
## What
- Added the ability to optionally publish the state after creating the initial plan and after the task completes to a redis queue

## Verification
Ran redis locally in docker, published messages to the stream `plan_execution` then exec-ed into the Docker container to verify that it works

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/d1629287-0ef2-4e2f-86ae-7e90a7f96fad" />

Then installed the agent into another AI as a package, and wrote a consumer in that API that listens to the stream. verified via swagger API call that it can consume

![image](https://github.com/user-attachments/assets/bd0e3ed7-20e9-49bc-b44e-af0f7eccbfcf)
