### PR TITLE
David/step executor max iteratitons

### DIFF
--- a/src/plan_exec_agent/step_executor.py
+++ b/src/plan_exec_agent/step_executor.py
@@ -283,5 +283,7 @@ class StepExecutor:
                 break
 
             i += 1
+            if i == max_iterations:
+                print(f"WARNING:Max iterations reached: {max_iterations}.\nExiting loop.")
 
         return final_text


### PR DESCRIPTION
## What
- Added a default max_iterations of 25 to the step executor
- fixed bug that user context was not injected into `step_executor`


## Verification

Can see the `user_context` is now included in the step executor - image via debugger

<img width="990" alt="image" src="https://github.com/user-attachments/assets/3d21d64a-e35d-4bb5-b84f-9da12c938f10" />
